### PR TITLE
fix: return correct type for successful broadcasts

### DIFF
--- a/.changeset/tough-chairs-look.md
+++ b/.changeset/tough-chairs-look.md
@@ -1,5 +1,5 @@
 ---
-"micro-stacks": patch
+"micro-stacks": minor
 ---
 
 fix: return correct type for successful broadcasts for `broadcastTransaction`

--- a/.changeset/tough-chairs-look.md
+++ b/.changeset/tough-chairs-look.md
@@ -1,0 +1,5 @@
+---
+"micro-stacks": patch
+---
+
+fix: return correct type for successful broadcasts for `broadcastTransaction`

--- a/src/transactions/builders/builders.test.ts
+++ b/src/transactions/builders/builders.test.ts
@@ -1408,7 +1408,7 @@ describe('tx builders', function () {
     expect((result as TxBroadcastResultRejected).reason_data).toEqual(rejection.reason_data);
   });
 
-  test('Transaction broadcast fails', async () => {
+  test('Transaction broadcast throws if non-json response', async () => {
     const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
     const amount = 12345;
     const fee = 0;

--- a/src/transactions/fetchers/broadcast-transaction.ts
+++ b/src/transactions/fetchers/broadcast-transaction.ts
@@ -14,7 +14,7 @@ const validateTxId = (txid: string): boolean => {
   return with0x(BigInt(value).toString(16).padStart(64, '0')) === value;
 };
 
-export type TxBroadcastResultOk = string;
+export type TxBroadcastResultOk = { txid: string };
 export type TxBroadcastResultRejected = {
   error: string;
   reason: TxRejectedReason;
@@ -66,7 +66,7 @@ export async function broadcastRawTransaction(
   const response = await fetchPrivate(url, options);
   if (!response.ok) {
     try {
-      return (await response.json()) as TxBroadcastResult;
+      return (await response.json()) as TxBroadcastResultRejected;
     } catch (e) {
       throw Error(`Failed to broadcast transaction: ${(e as Error).message}`);
     }
@@ -78,7 +78,7 @@ export async function broadcastRawTransaction(
   if (validateTxId(txid))
     return {
       txid,
-    } as TxBroadcastResult;
+    } as TxBroadcastResultOk;
 
   throw new Error(text);
 }


### PR DESCRIPTION
In the latest micro-stacks, `broadcastTransaction` returns `{ txid: string }`, but that's not the TypeScript type. You need to do funky workarounds when using this library in TS to get the result you want.

A different option is to actually return a `string`, which would also fix the issue (and be backwards compat with stacks.js?)