### PR TITLE
fix: pass tip option to read-only api

### DIFF
--- a/.changeset/metal-actors-float.md
+++ b/.changeset/metal-actors-float.md
@@ -1,0 +1,5 @@
+---
+'micro-stacks': patch
+---
+
+Adds the `tip` query parameter to read-only API calls. `tip` was already a parameter to the `callReadOnlyFunction` function, but it wasn't actually passed to the API call.

--- a/src/api/read-only/call-read-only-function.ts
+++ b/src/api/read-only/call-read-only-function.ts
@@ -26,6 +26,7 @@ export async function callReadOnlyFunction<T extends ClarityValue>(
     functionName,
     functionArgs,
     senderAddress = contractAddress,
+    tip,
   } = options;
 
   let network = options.network;
@@ -42,7 +43,10 @@ export async function callReadOnlyFunction<T extends ClarityValue>(
 
   if (!network) throw Error('[micro-stacks] callReadOnlyFunction -> no network defined');
 
-  const url = network.getReadOnlyFunctionCallApiUrl(contractAddress, contractName, functionName);
+  let url = network.getReadOnlyFunctionCallApiUrl(contractAddress, contractName, functionName);
+  if (tip) {
+    url += `?tip=${tip}`;
+  }
 
   const body = JSON.stringify({
     sender: senderAddress,


### PR DESCRIPTION
Adds the `tip` query parameter to read-only API calls. `tip` was already a parameter to the `callReadOnlyFunction` function, but it wasn't actually passed to the API call.