### PR TITLE
fix: recursive require in crypto

### DIFF
--- a/.changeset/slow-clocks-divide.md
+++ b/.changeset/slow-clocks-divide.md
@@ -1,0 +1,5 @@
+---
+'micro-stacks': patch
+---
+
+Fixed an issue where requiring "micro-stacks/crypto" would throw a recursive require error in node.js contexts.

--- a/src/crypto/base58/addresses.ts
+++ b/src/crypto/base58/addresses.ts
@@ -1,4 +1,4 @@
-import { getPublicKey } from 'micro-stacks/crypto';
+import { getPublicKey } from '../public-key';
 import { BufferArray, bytesToHex, ensureHexBytes, hexToBytes } from 'micro-stacks/common';
 import { hashSha256 } from 'micro-stacks/crypto-sha';
 

--- a/src/crypto/encryption/encrypt-content.ts
+++ b/src/crypto/encryption/encrypt-content.ts
@@ -1,4 +1,4 @@
-import { getPublicKey } from 'micro-stacks/crypto';
+import { getPublicKey } from '../public-key';
 import { bytesToHex, utf8ToBytes } from 'micro-stacks/common';
 import { encryptECIES } from './encrypt-ecies';
 import { signECDSA } from './sign';


### PR DESCRIPTION
Fixed an issue where requiring "micro-stacks/crypto" would throw a recursive require error in node.js / commonjs contexts.