### PR TITLE
fix: remove superfluos wording

### DIFF
--- a/apps/docs/pages/docs/getting-started/advanced-patterns.en-US.mdx
+++ b/apps/docs/pages/docs/getting-started/advanced-patterns.en-US.mdx
@@ -36,7 +36,7 @@ authentication gate for restricted areas of an application.
 
 ### `onPersistState`
 
-To get access the client state to persist, you pass a callback `onPersistState` to the client which
+To get the client state to persist, you pass a callback `onPersistState` to the client which
 fires whenever the state changes. `onPersistState` is a function that takes a string value of
 `dehydratedState`.
 


### PR DESCRIPTION
it seems one of "get" or "access" isn't needed so i removed "access" but let me know if the intention was something else here.