### PR TITLE
fix: spelling mistake and friendlier language

### DIFF
--- a/apps/docs/pages/docs/message-signing/standard-messages.en-US.mdx
+++ b/apps/docs/pages/docs/message-signing/standard-messages.en-US.mdx
@@ -23,7 +23,7 @@ Standard messaging signing allows for the signing of any arbitrary string messag
 
 `@micro-stacks/react` exports a hook for this: `useOpenSignMessage`. The hook returns a callback,
 `openSignMessage` which takes a `message` of type `string` value. `isRequestPending` is also
-returned, a boolean value to denote if there is a current request open (meaning the use has already
+returned, a boolean value to denote if there is a current request open (meaning the user has already
 requested a signature). The pending state is handled all internally for every wallet request, so you
 don't need to manually handle any loading logic.
 
@@ -40,7 +40,7 @@ import { useOpenStxTokenTransfer } from '@micro-stacks/react';
 
 `@micro-stacks/svelte` exports a function for this: `getOpenSignMessage`. The function returns a
 callback, `openSignMessage` which takes a `message` of type `string` value. `isRequestPending` is
-also returned, a boolean value to denote if there is a current request open (meaning the use has
+also returned, a boolean value to denote if there is a current request open (meaning the user has
 already requested a signature). The pending state is handled all internally for every wallet
 request, so you don't need to manually handle any loading logic.
 
@@ -57,7 +57,7 @@ import { getOpenStxTokenTransfer } from '@micro-stacks/svelte';
 
 `@micro-stacks/vue` exports a hook for this: `useOpenSignMessage`. The hook returns a callback,
 `openSignMessage` which takes a `message` of type `string` value. `isRequestPending` is also
-returned, a boolean value to denote if there is a current request open (meaning the use has already
+returned, a boolean value to denote if there is a current request open (meaning the user has already
 requested a signature). The pending state is handled all internally for every wallet request, so you
 don't need to manually handle any loading logic.
 
@@ -74,7 +74,7 @@ import { useOpenStxTokenTransfer } from '@micro-stacks/vue';
 
 `@micro-stacks/solidjs` exports a hook for this: `useOpenSignMessage`. The hook returns a callback,
 `openSignMessage` which takes a `message` of type `string` value. `isRequestPending` is also
-returned, a boolean value to denote if there is a current request open (meaning the use has already
+returned, a boolean value to denote if there is a current request open (meaning the user has already
 requested a signature). The pending state is handled all internally for every wallet request, so you
 don't need to manually handle any loading logic.
 
@@ -97,7 +97,7 @@ As with all of the hooks that interact with the wallet, you can also pass an `on
 `onCancel` callback.
 
 To check the status of a request, you can check `client.isSignMessageRequestPending`, a boolean
-value to denote if there is a current request open (meaning the use has already requested a
+value to denote if there is a current request open (meaning the user has already requested a
 signature). The pending state is handled all internally for every wallet request, so you don't need
 to manually handle any loading logic.
 
@@ -106,7 +106,7 @@ to manually handle any loading logic.
 ## Example
 
 <Integrations.React>
-Below you will find a simple component that renders an input and a button. The input is captured in a `useState` hook, and piped
+Below you will find a component that renders an input and a button. The input is captured in a `useState` hook, and piped
 into the `openSignMessage` callback, wrapped in a `useCallback` hook.
 
 ```jsx
@@ -152,7 +152,7 @@ const SignMessageComponent = () => {
 </Integrations.React>
 
 <Integrations.Svelte>
-Below you will find a simple component that renders an input and a button, the message from the input is fed to the onSignMessage function, which gets sent to the connected wallet.
+Below you will find a component that renders an input and a button, the message from the input is fed to the onSignMessage function, which gets sent to the connected wallet.
 
 ```svelte
 <script lang='ts'>
@@ -206,7 +206,7 @@ Below you will find a simple component that renders an input and a button, the m
 </Integrations.Vue>
 
 <Integrations.Solid>
-Below you will find a simple component that renders an input and a button. The input is captured in a signal using `createSignal`, and piped
+Below you will find a component that renders an input and a button. The input is captured in a signal using `createSignal`, and piped
 into the `openSignMessage` callback.
 
 ```tsx


### PR DESCRIPTION
i removed the word "simple" from here because i have heard a few people saying it can be a bit demoralising for beginners who don't find the code simple at all. 

i really need to get out of the habit of using this word too 🙈 
