### PR TITLE
fix: correct package imports & reduce code example

### DIFF
--- a/apps/docs/pages/docs/authentication.en-US.mdx
+++ b/apps/docs/pages/docs/authentication.en-US.mdx
@@ -153,21 +153,6 @@ import { useAuth } from '@micro-stacks/solidjs';
 export const WalletConnectButton = () => {
   const { openAuthRequest, signOut, isRequestPending, isSignedIn } = useAuth();
 
-  const label = (
-    <Show
-      when={isRequestPending()}
-      fallback={
-        <Show
-          when={!isSignedIn()}
-          fallback={'Sign out'}
-        >
-          Connect Stacks Wallet
-        </Show>
-      }
-    >
-      Loading...
-    </Show>
-  );
   return (
     <button
       onClick={() => {
@@ -175,7 +160,11 @@ export const WalletConnectButton = () => {
         else void openAuthRequest();
       }}
     >
-      {label}
+      <Solid.Show when={!isRequestPending()} fallback={"Loading..."}>
+        <Solid.Show when={!isSignedIn()} fallback={"Sign out"}>
+          Connect Stacks Wallet
+        </Solid.Show>
+      </Solid.Show>
     </button>
   );
 };
@@ -329,7 +318,7 @@ interface Account {
 To access the current signed in user data, you'll want to make use of the `useAccount` hook:
 
 ```ts
-import { useAccount } from '@micro-stacks/solid';
+import { useAccount } from '@micro-stacks/solidjs';
 ```
 
 This hook will return a _reactive_ (will automatically update as state changes) object with the
@@ -347,7 +336,7 @@ interface Account {
 ```
 
 ```ts
-import { useAccount } from '@micro-stacks/solid';
+import { useAccount } from '@micro-stacks/solidjs';
 
 const account = useAccount();
 


### PR DESCRIPTION
i updated the wallet connect code example here because initially i thought the `label` wouldn't be reactive given it is declared in the component scope (instead of the `return`) but TIL that solidjs will make anything wrapped in JSX reactive even if it is declared outside of the `return`....

so `const foo = <>{signalValue()}</>` would work but `const foo = signalValue()` wouldn't 🙈.

while clever, it seemed a bit confusing so i just simplified things a bit.