### PR TITLE
Use name instead of address to fetch zone file

### DIFF
--- a/packages/client/src/micro-stacks-client.ts
+++ b/packages/client/src/micro-stacks-client.ts
@@ -716,7 +716,8 @@ export class MicroStacksClient {
         console.warn('No Stacks address found while trying to fetch zonefile name');
         return undefined;
       }
-      const path = network.getCoreApiUrl() + `/v1/names/${stxAddress}/zonefile`;
+      const name = await this.fetchBNSName();
+      const path = network.getCoreApiUrl() + `/v1/names/${name}/zonefile`;
       const res = await this.fetcher(path);
       const payload = await res.json();
       return payload as { zonefile: string; address: string };


### PR DESCRIPTION
Core api expects a name instead of an address. This _should_ fix issue #169 but I'm not able to test it because I'm unable to invest the time now to figure out how to include local packages from a monorepo in my project. If someone wants to point me towards instructions, I'm happy to try it out!