### PR TITLE
Add check for `0x` in hex string

### DIFF
--- a/.changeset/sixty-ravens-swim.md
+++ b/.changeset/sixty-ravens-swim.md
@@ -1,0 +1,5 @@
+---
+"micro-stacks": patch
+---
+
+Add check for `0x` in hex string

--- a/packages/core/src/common/encoding-hex.ts
+++ b/packages/core/src/common/encoding-hex.ts
@@ -10,7 +10,7 @@ for (let n = 0; n <= 0xff; ++n) {
 export function hexToBytes(hex: string): Uint8Array {
   if (typeof hex !== 'string')
     throw new TypeError('hexToBytes: expected string, got ' + typeof hex);
-  if (hex.startsWith('0x')) hex = hex.slice(2);
+  if (hex.startsWith('0x')) hex = cleanHex(hex);
   if (hex.length % 2)
     throw new Error(`hexToBytes: received invalid unpadded hex, got: ${hex.length}`);
   const array = new Uint8Array(hex.length / 2);

--- a/packages/core/src/common/encoding-hex.ts
+++ b/packages/core/src/common/encoding-hex.ts
@@ -10,6 +10,7 @@ for (let n = 0; n <= 0xff; ++n) {
 export function hexToBytes(hex: string): Uint8Array {
   if (typeof hex !== 'string')
     throw new TypeError('hexToBytes: expected string, got ' + typeof hex);
+  if (hex.startsWith('0x')) hex = hex.slice(2);
   if (hex.length % 2)
     throw new Error(`hexToBytes: received invalid unpadded hex, got: ${hex.length}`);
   const array = new Uint8Array(hex.length / 2);


### PR DESCRIPTION
This updates `hexToBytes()` to remove the `0x` in a string if detected, which fixes #171.

Originally I just used `if (hex.startsWith('0x')) hex = hex.slice(2);` but then found the `cleanHex()` function at the bottom and used that instead.

Is this the only spot that needs to be updated?

