### PR TITLE
feat: allow custom statement for getSignInMessage

### DIFF
--- a/.changeset/rare-adults-collect.md
+++ b/.changeset/rare-adults-collect.md
@@ -1,0 +1,5 @@
+---
+'@micro-stacks/client': patch
+---
+
+Allow custom statement for getSignInMessage.

--- a/packages/client/src/micro-stacks-client.ts
+++ b/packages/client/src/micro-stacks-client.ts
@@ -417,10 +417,12 @@ export class MicroStacksClient {
     domain,
     nonce,
     version = '1.0.0',
+    statement = 'Sign in with Stacks',
   }: {
     domain?: string;
     nonce: string;
     version?: string;
+    statement?: string;
   }) => {
     if (!this.handleNoStacksProviderFound()) return;
 
@@ -438,7 +440,7 @@ export class MicroStacksClient {
     return new SignInWithStacksMessage({
       domain: appDetails.name,
       address: stxAddress,
-      statement: 'Sign in with Stacks',
+      statement,
       uri: domain ?? fallbackUri,
       version,
       chainId: ChainID.Mainnet,


### PR DESCRIPTION
As an app I want to be able to show a custom statement including the privacy policy of the app.