### PR TITLE
feat: export SignInWithStacksMessage class so it can be used

### DIFF
--- a/.changeset/thin-eggs-walk.md
+++ b/.changeset/thin-eggs-walk.md
@@ -1,0 +1,5 @@
+---
+'@micro-stacks/client': minor
+---
+
+Export SignInWithStacksMessage class.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -5,3 +5,4 @@ export * from './common/constants';
 export * from './common/storage';
 export { cleanDehydratedState } from './utils';
 export * from './getters';
+export * from './siwms';


### PR DESCRIPTION
In order to verify the message server side we need to reconstruct the message with the SignInWithStacksMessage, however this class is not exported. The pr makes this class accessible by apps.