### PR TITLE
fix: fix invalid message version

### DIFF
--- a/.changeset/young-cows-smoke.md
+++ b/.changeset/young-cows-smoke.md
@@ -1,0 +1,5 @@
+---
+'@micro-stacks/client': patch
+---
+
+Fix default version in getSignInMessage.

--- a/packages/client/src/micro-stacks-client.ts
+++ b/packages/client/src/micro-stacks-client.ts
@@ -416,7 +416,7 @@ export class MicroStacksClient {
   getSignInMessage = ({
     domain,
     nonce,
-    version = '1.0.0',
+    version = '1',
     statement = 'Sign in with Stacks',
   }: {
     domain?: string;


### PR DESCRIPTION
Calling `getSignInMessage` is throwing the following error `{type: 'Invalid message version.', expected: '1', received: '1.0.0'}`. This pr changes the default version to make it work with `SignInWithStacksMessage`.